### PR TITLE
Add AI-driven live trading scaffolding

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # 🧠 TraderDesk
 
-**TraderDesk** is a desktop trading research tool built in Python.  
-It lets you visualize and backtest simple trading strategies (like SMA crossovers) using **free market data** from Yahoo Finance.
+**TraderDesk** is a desktop trading research tool built in Python.
+It lets you visualize and backtest simple trading strategies (like SMA crossovers) using **free market data** from Yahoo Finance today, and it is being expanded into an **AI-assisted live-trading workstation**.
 
 ---
 
@@ -16,6 +16,7 @@ Example: SPY with 50/200 SMA crossover
 - 📈 Plot price with customizable moving averages
 - ⚙️ Backtest basic crossover strategies
 - 🧮 Display key performance metrics (CAGR, Sharpe, Sortino, Max Drawdown)
+- 🤖 Prototype AI predictor for next-bar returns and trade confidence
 - 🪟 Simple GUI built with `PySide6`
 
 ---
@@ -63,12 +64,43 @@ pip install -r requirements.txt
 python traderdesk.py
 ```
 
-This project is for learning algorithmic trading — not for live trading or financial advice:
+> ⚠️ **Work in Progress:** TraderDesk is actively evolving toward a live trading platform. The current release focuses on research and backtesting while the team builds out the broker connectivity, execution, and risk controls required for production use.
 
-Fetch and clean market data
+### 🛣️ Live Trading Roadmap Highlights
+- ✅ **Today:** Research workflow with historical market data, signal generation, performance analytics, and an AI predictor powering the live engine prototype.
+- 🚧 **In Development:** Modular execution engine hardening, broker API integration, and real-time data ingestion.
+- 🗓️ **Planned:** Automated risk management, monitoring dashboards, compliance tooling, and multi-asset portfolio coordination for safe live deployment.
 
-Generate trading signals
+### 🧭 What You Can Do Right Now
+- Fetch and clean market data
+- Generate trading signals
+- Backtest strategies with realistic assumptions
+- Interpret performance metrics
+- Experiment with the new AI predictor and paper-broker live trading engine scaffolding
 
-Backtest strategies with realistic assumptions
+---
 
-Interpret performance metrics
+## 🧠 Getting Started with AI-Assisted Live Trading
+
+The `traderdesk.ai` module introduces a lightweight ridge-regression predictor that learns from historical closing prices and estimates the next-bar return with an associated confidence score. The live trading prototype wires this predictor into a modular engine that can be pointed at a real broker once credentials and compliance checks are ready.
+
+```python
+from traderdesk import (
+    AIPredictor,
+    LiveTradingConfig,
+    LiveTradingEngine,
+    PaperBroker,
+    YahooMarketDataProvider,
+)
+
+config = LiveTradingConfig(ticker="SPY", trade_threshold=0.0015, trade_size=10)
+predictor = AIPredictor(lookback=30)
+data_provider = YahooMarketDataProvider()
+broker = PaperBroker()
+
+engine = LiveTradingEngine(config, predictor, data_provider, broker)
+decision = engine.evaluate_and_execute()
+print(decision)
+```
+
+> ⚠️ **Important:** The live trading components currently target a paper broker and do not handle order routing, authentication, or regulatory checks. They are meant for experimentation while the production integrations are being built.

--- a/traderdesk/__init__.py
+++ b/traderdesk/__init__.py
@@ -1,5 +1,26 @@
 """Core package for the TraderDesk application."""
 
 from .app import main
+from .ai import AIPredictor, PredictionResult
+from .live import (
+    BrokerClient,
+    LiveTradingConfig,
+    LiveTradingEngine,
+    MarketDataProvider,
+    PaperBroker,
+    TradeDecision,
+    YahooMarketDataProvider,
+)
 
-__all__ = ["main"]
+__all__ = [
+    "main",
+    "AIPredictor",
+    "PredictionResult",
+    "LiveTradingConfig",
+    "LiveTradingEngine",
+    "TradeDecision",
+    "MarketDataProvider",
+    "YahooMarketDataProvider",
+    "BrokerClient",
+    "PaperBroker",
+]

--- a/traderdesk/ai/__init__.py
+++ b/traderdesk/ai/__init__.py
@@ -1,0 +1,5 @@
+"""AI helpers for predictive trading workflows."""
+
+from .predictor import AIPredictor, PredictionResult
+
+__all__ = ["AIPredictor", "PredictionResult"]

--- a/traderdesk/ai/predictor.py
+++ b/traderdesk/ai/predictor.py
@@ -1,0 +1,107 @@
+"""Lightweight predictive model for next-bar return estimation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass(slots=True)
+class PredictionResult:
+    """Container for a return prediction and supporting metadata."""
+
+    expected_return: float
+    confidence: float
+    samples: int
+
+    @property
+    def direction(self) -> int:
+        """Return the trading direction implied by the prediction."""
+
+        if self.expected_return > 0:
+            return 1
+        if self.expected_return < 0:
+            return -1
+        return 0
+
+
+class AIPredictor:
+    """Simple ridge-regression model built on lagged return features."""
+
+    def __init__(
+        self,
+        lookback: int = 20,
+        regularization: float = 1e-4,
+        min_history: Optional[int] = None,
+    ) -> None:
+        if lookback <= 0:
+            raise ValueError("lookback must be positive")
+        if regularization < 0:
+            raise ValueError("regularization must be non-negative")
+        self.lookback = lookback
+        self.regularization = regularization
+        self._weights: Optional[np.ndarray] = None
+        self._bias: float = 0.0
+        self.min_history = max(lookback + 1, min_history or 0)
+
+    @staticmethod
+    def _to_series(values: Iterable[float]) -> pd.Series:
+        series = pd.Series(values, dtype="float64")
+        return series.dropna()
+
+    def _build_design_matrix(self, closes: pd.Series) -> tuple[np.ndarray, np.ndarray]:
+        returns = closes.pct_change().dropna()
+        if len(returns) <= self.lookback:
+            raise ValueError("insufficient data to build features")
+        features = []
+        targets = []
+        for end in range(self.lookback, len(returns)):
+            window = returns.iloc[end - self.lookback : end]
+            features.append(window.to_numpy())
+            targets.append(returns.iloc[end])
+        X = np.asarray(features, dtype="float64")
+        y = np.asarray(targets, dtype="float64")
+        return X, y
+
+    def fit(self, closes: Iterable[float]) -> PredictionResult:
+        """Fit ridge regression weights using *closes* price history."""
+
+        series = self._to_series(closes)
+        if len(series) < self.min_history:
+            raise ValueError("not enough history to fit predictor")
+        X, y = self._build_design_matrix(series)
+        XtX = X.T @ X
+        ridge = XtX + self.regularization * np.identity(XtX.shape[0])
+        XtY = X.T @ y
+        weights = np.linalg.solve(ridge, XtY)
+        bias = y.mean() - weights.mean()
+        self._weights = weights
+        self._bias = float(bias)
+        # Provide a backtest-style in-sample prediction for transparency.
+        mean_pred = float((X @ weights + bias).mean())
+        variance = float(np.var(y - (X @ weights + bias))) if len(y) > 1 else 0.0
+        confidence = 1.0 / (1.0 + variance)
+        return PredictionResult(expected_return=mean_pred, confidence=confidence, samples=len(y))
+
+    def is_trained(self) -> bool:
+        return self._weights is not None
+
+    def predict(self, closes: Iterable[float]) -> PredictionResult:
+        """Predict the next-bar return from closing prices."""
+
+        series = self._to_series(closes)
+        if len(series) < self.lookback:
+            raise ValueError("not enough history to predict")
+        if not self.is_trained():
+            self.fit(series)
+        assert self._weights is not None
+        window = series.iloc[-self.lookback :]
+        features = window.to_numpy()
+        expected = float(features @ self._weights + self._bias)
+        # Confidence decays with prediction magnitude relative to historical dispersion.
+        dispersion = float(np.std(features)) if len(features) > 1 else 1.0
+        confidence = 1.0 / (1.0 + abs(expected) / max(dispersion, 1e-9))
+        return PredictionResult(expected_return=expected, confidence=confidence, samples=len(series))

--- a/traderdesk/live/__init__.py
+++ b/traderdesk/live/__init__.py
@@ -1,0 +1,15 @@
+"""Live trading orchestration primitives."""
+
+from .engine import LiveTradingConfig, LiveTradingEngine, TradeDecision
+from .providers import MarketDataProvider, YahooMarketDataProvider
+from .brokers import BrokerClient, PaperBroker
+
+__all__ = [
+    "LiveTradingConfig",
+    "LiveTradingEngine",
+    "TradeDecision",
+    "MarketDataProvider",
+    "YahooMarketDataProvider",
+    "BrokerClient",
+    "PaperBroker",
+]

--- a/traderdesk/live/brokers.py
+++ b/traderdesk/live/brokers.py
@@ -1,0 +1,54 @@
+"""Broker abstraction for live trading."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Protocol
+
+
+@dataclass(slots=True)
+class Order:
+    """Represents an order request that can be sent to a broker."""
+
+    ticker: str
+    quantity: int
+    side: str
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass(slots=True)
+class Position:
+    """Holds the current position state for a single ticker."""
+
+    ticker: str
+    quantity: int = 0
+
+
+class BrokerClient(Protocol):
+    """Protocol representing the minimum interface for live trading."""
+
+    def submit(self, order: Order) -> None:
+        """Send an order to the broker."""
+
+    def position(self, ticker: str) -> Position:
+        """Return the latest known position for *ticker*."""
+
+
+class PaperBroker:
+    """Simple in-memory broker useful for prototyping the engine."""
+
+    def __init__(self) -> None:
+        self._positions: Dict[str, Position] = {}
+
+    def submit(self, order: Order) -> None:
+        pos = self._positions.setdefault(order.ticker, Position(ticker=order.ticker))
+        if order.side == "BUY":
+            pos.quantity += order.quantity
+        elif order.side == "SELL":
+            pos.quantity -= order.quantity
+        else:
+            raise ValueError(f"Unsupported order side: {order.side}")
+
+    def position(self, ticker: str) -> Position:
+        return self._positions.get(ticker, Position(ticker=ticker))

--- a/traderdesk/live/engine.py
+++ b/traderdesk/live/engine.py
@@ -1,0 +1,93 @@
+"""Live trading engine orchestrating AI predictions and execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from ..ai import AIPredictor
+from .brokers import BrokerClient, Order
+from .providers import MarketDataProvider
+
+
+@dataclass(slots=True)
+class LiveTradingConfig:
+    """Configuration used by the live engine."""
+
+    ticker: str
+    lookback_days: int = 120
+    min_confidence: float = 0.4
+    trade_threshold: float = 0.001
+    trade_size: int = 1
+
+
+@dataclass(slots=True)
+class TradeDecision:
+    """Captures the outcome of a decision cycle."""
+
+    should_trade: bool
+    reason: str
+    predicted_return: float
+    confidence: float
+    target_position: int
+
+
+class LiveTradingEngine:
+    """Combine AI signal generation with broker execution hooks."""
+
+    def __init__(
+        self,
+        config: LiveTradingConfig,
+        predictor: Optional[AIPredictor],
+        data_provider: MarketDataProvider,
+        broker: BrokerClient,
+    ) -> None:
+        self.config = config
+        self.predictor = predictor or AIPredictor()
+        self.data_provider = data_provider
+        self.broker = broker
+
+    def evaluate(self) -> TradeDecision:
+        snapshot = self.data_provider.fetch(self.config.ticker, self.config.lookback_days)
+        prediction = self.predictor.predict(snapshot.closes)
+        if prediction.confidence < self.config.min_confidence:
+            return TradeDecision(
+                should_trade=False,
+                reason="low confidence",
+                predicted_return=prediction.expected_return,
+                confidence=prediction.confidence,
+                target_position=0,
+            )
+        if abs(prediction.expected_return) < self.config.trade_threshold:
+            return TradeDecision(
+                should_trade=False,
+                reason="return below threshold",
+                predicted_return=prediction.expected_return,
+                confidence=prediction.confidence,
+                target_position=0,
+            )
+        direction = 1 if prediction.expected_return > 0 else -1
+        target_position = direction * self.config.trade_size
+        return TradeDecision(
+            should_trade=True,
+            reason="threshold met",
+            predicted_return=prediction.expected_return,
+            confidence=prediction.confidence,
+            target_position=target_position,
+        )
+
+    def execute(self, decision: TradeDecision) -> None:
+        if not decision.should_trade:
+            return
+        current = self.broker.position(self.config.ticker).quantity
+        delta = decision.target_position - current
+        if delta == 0:
+            return
+        side = "BUY" if delta > 0 else "SELL"
+        order = Order(ticker=self.config.ticker, quantity=abs(delta), side=side)
+        self.broker.submit(order)
+
+    def evaluate_and_execute(self) -> TradeDecision:
+        decision = self.evaluate()
+        self.execute(decision)
+        return decision

--- a/traderdesk/live/providers.py
+++ b/traderdesk/live/providers.py
@@ -1,0 +1,39 @@
+"""Market data providers for live trading components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Protocol
+
+import pandas as pd
+
+from ..data import get_data
+
+
+@dataclass(slots=True)
+class MarketDataSnapshot:
+    """Holds the latest price information required by the engine."""
+
+    closes: pd.Series
+    as_of: datetime
+
+
+class MarketDataProvider(Protocol):
+    """Protocol describing how live modules receive market data."""
+
+    def fetch(self, ticker: str, lookback_days: int) -> MarketDataSnapshot:
+        """Return an ordered series of closing prices for *ticker*."""
+
+
+class YahooMarketDataProvider:
+    """Fetch historical bars using the existing Yahoo Finance loader."""
+
+    def fetch(self, ticker: str, lookback_days: int) -> MarketDataSnapshot:
+        end = datetime.utcnow()
+        start = end - timedelta(days=lookback_days * 2)
+        df = get_data(ticker, start=start.strftime("%Y-%m-%d"), end=end.strftime("%Y-%m-%d"))
+        closes = df["Adj Close"].tail(lookback_days)
+        if closes.empty:
+            raise ValueError(f"No closing prices available for {ticker}")
+        return MarketDataSnapshot(closes=closes, as_of=end)


### PR DESCRIPTION
## Summary
- update the README introduction to note TraderDesk is evolving into an AI-assisted live-trading workstation and document how to experiment with the new components
- add a roadmap callout describing current, in-development, and planned live trading milestones along with guidance on available workflows during the WIP phase
- introduce an AI predictor module and live trading engine scaffolding with market data and paper broker abstractions to start building execution features

## Testing
- python -m compileall traderdesk

------
https://chatgpt.com/codex/tasks/task_e_68e3d1d8d09083308dd6614700c11b70