### PR TITLE
Add crypto day trading panel with AI support

### DIFF
--- a/traderdesk/data.py
+++ b/traderdesk/data.py
@@ -6,11 +6,39 @@ import pandas as pd
 import yfinance as yf
 
 
-def get_data(ticker: str, start: str, end: str) -> pd.DataFrame:
-    """Fetch historical price data for *ticker* between *start* and *end*."""
-    df = yf.download(ticker, start=start, end=end, auto_adjust=False, progress=False)
+def _normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Return *df* with flattened column names and without missing rows."""
+
     if df.empty:
-        raise ValueError(f"No data for {ticker}")
+        return df
     if isinstance(df.columns, pd.MultiIndex):
         df.columns = df.columns.get_level_values(0)
     return df.dropna().copy()
+
+
+def get_data(ticker: str, start: str, end: str) -> pd.DataFrame:
+    """Fetch historical price data for *ticker* between *start* and *end*."""
+
+    df = yf.download(ticker, start=start, end=end, auto_adjust=False, progress=False)
+    if df.empty:
+        raise ValueError(f"No data for {ticker}")
+    return _normalize_columns(df)
+
+
+def get_crypto_intraday(
+    symbol: str, *, period: str = "7d", interval: str = "15m"
+) -> pd.DataFrame:
+    """Retrieve intraday crypto price history suitable for day-trading panels."""
+
+    if not symbol:
+        raise ValueError("symbol must be provided")
+    df = yf.download(
+        symbol,
+        period=period,
+        interval=interval,
+        auto_adjust=False,
+        progress=False,
+    )
+    if df.empty:
+        raise ValueError(f"No data for {symbol} at interval {interval}")
+    return _normalize_columns(df)


### PR DESCRIPTION
## Summary
- add dedicated crypto day-trading tab with intraday charting controls
- integrate AI predictor to analyze intraday crypto closes and surface directional guidance
- extend data utilities with reusable normalization helper and crypto intraday loader

## Testing
- python -m compileall traderdesk

------
https://chatgpt.com/codex/tasks/task_e_68e53767cc7483309bcdb286a6ed52c6